### PR TITLE
feat(dropdown): implement dynamic category dropdown for expenses and income

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,14 +6,17 @@ import "./app.css";
 import "./responsive.css";
 
 import ExpenseProvider from "./contexts/ExpenseContext";
+import CategoryContextProvider from "./contexts/CategoryContext";
 
 export default function App() {
   return (
     <ExpenseProvider>
-      <div id="app">
-        <PageHeader></PageHeader>
-        <Dashboard />
-      </div>
+      <CategoryContextProvider>
+        <div id="app">
+          <PageHeader></PageHeader>
+          <Dashboard />
+        </div>
+      </CategoryContextProvider>
     </ExpenseProvider>
   );
 }

--- a/src/constants/category.js
+++ b/src/constants/category.js
@@ -29,3 +29,33 @@ export const DEFAULT_CATEGORIES = {
         { text: "⚙️ Miscellaneous", value: "miscellaneous" }
     ]
 };
+
+export const CATEGORY_MAP = {
+    // Income
+    salary: "💼 Salary",
+    investments: "📈 Investments",
+    rental: "🏠 Rental",
+    bonuses: "🎁 Bonuses",
+    freelance: "💻 Freelance",
+    refunds: "💸 Refunds",
+    awards: "🏆 Awards",
+    // Expenses
+    groceries: "🍎 Groceries",
+    rent: "🏠 Rent",
+    transport: "🚗 Transport",
+    utilities: "💡 Utilities",
+    healthcare: "🏥 Healthcare",
+    clothing: "👕 Clothing",
+    dining_out: "🍽️ Dining Out",
+    entertainment: "🎬 Entertainment",
+    travel: "✈️ Travel",
+    fitness: "🏋️ Fitness",
+    shopping: "🛍️ Shopping",
+    loan: "💳 Loan",
+    savings: "🏦 Savings",
+    taxes: "🧾 Taxes",
+    donations: "🎉 Donations",
+    pets: "🐶 Pets",
+    education: "📚 Education",
+    miscellaneous: "⚙️ Miscellaneous"
+};

--- a/src/constants/category.js
+++ b/src/constants/category.js
@@ -1,0 +1,31 @@
+export const DEFAULT_CATEGORIES = {
+    income: [
+        "💼 Salary",
+        "📈 Investments",
+        "🏠 Rental",
+        "🎁 Bonuses",
+        "💻 Freelance",
+        "💸 Refunds",
+        "🏆 Awards"
+    ],
+    expenses: [
+        "🍎 Groceries",
+        "🏠 Rent",
+        "🚗 Transport",
+        "💡 Utilities",
+        "🏥 Healthcare",
+        "👕 Clothing",
+        "🍽️ Dining Out",
+        "🎬 Entertainment",
+        "✈️ Travel",
+        "🏋️ Fitness",
+        "🛍️ Shopping",
+        "💳 Loan",
+        "🏦 Savings",
+        "🧾 Taxes",
+        "🎉 Donations",
+        "🐶 Pets",
+        "📚 Education",
+        "⚙️ Miscellaneous"
+    ]
+};

--- a/src/constants/category.js
+++ b/src/constants/category.js
@@ -1,31 +1,31 @@
 export const DEFAULT_CATEGORIES = {
     income: [
-        "💼 Salary",
-        "📈 Investments",
-        "🏠 Rental",
-        "🎁 Bonuses",
-        "💻 Freelance",
-        "💸 Refunds",
-        "🏆 Awards"
+        { text: "💼 Salary", value: "salary" },
+        { text: "📈 Investments", value: "investments" },
+        { text: "🏠 Rental", value: "rental" },
+        { text: "🎁 Bonuses", value: "bonuses" },
+        { text: "💻 Freelance", value: "freelance" },
+        { text: "💸 Refunds", value: "refunds" },
+        { text: "🏆 Awards", value: "awards" }
     ],
-    expenses: [
-        "🍎 Groceries",
-        "🏠 Rent",
-        "🚗 Transport",
-        "💡 Utilities",
-        "🏥 Healthcare",
-        "👕 Clothing",
-        "🍽️ Dining Out",
-        "🎬 Entertainment",
-        "✈️ Travel",
-        "🏋️ Fitness",
-        "🛍️ Shopping",
-        "💳 Loan",
-        "🏦 Savings",
-        "🧾 Taxes",
-        "🎉 Donations",
-        "🐶 Pets",
-        "📚 Education",
-        "⚙️ Miscellaneous"
+    expense: [
+        { text: "🍎 Groceries", value: "groceries" },
+        { text: "🏠 Rent", value: "rent" },
+        { text: "🚗 Transport", value: "transport" },
+        { text: "💡 Utilities", value: "utilities" },
+        { text: "🏥 Healthcare", value: "healthcare" },
+        { text: "👕 Clothing", value: "clothing" },
+        { text: "🍽️ Dining Out", value: "dining_out" },
+        { text: "🎬 Entertainment", value: "entertainment" },
+        { text: "✈️ Travel", value: "travel" },
+        { text: "🏋️ Fitness", value: "fitness" },
+        { text: "🛍️ Shopping", value: "shopping" },
+        { text: "💳 Loan", value: "loan" },
+        { text: "🏦 Savings", value: "savings" },
+        { text: "🧾 Taxes", value: "taxes" },
+        { text: "🎉 Donations", value: "donations" },
+        { text: "🐶 Pets", value: "pets" },
+        { text: "📚 Education", value: "education" },
+        { text: "⚙️ Miscellaneous", value: "miscellaneous" }
     ]
 };

--- a/src/contexts/CategoryContext.jsx
+++ b/src/contexts/CategoryContext.jsx
@@ -1,0 +1,18 @@
+import React, { createContext, useContext, useState } from "react";
+import { DEFAULT_CATEGORIES } from "../constants/category";
+
+const CategoryContext = createContext();
+
+const CategoryContextProvider = ({ children }) => {
+  const [categories, setCategories] = useState(DEFAULT_CATEGORIES);
+
+  return (
+    <CategoryContext.Provider value={{ categories, setCategories }}>
+      {children}
+    </CategoryContext.Provider>
+  );
+};
+
+export const useCategory = () => useContext(CategoryContext);
+
+export default CategoryContextProvider;

--- a/src/features/Transactions/components/AddTransaction/AddTransaction.jsx
+++ b/src/features/Transactions/components/AddTransaction/AddTransaction.jsx
@@ -3,6 +3,7 @@ import React, { useEffect, useRef, useState } from "react";
 import "./addTransaction.css";
 
 import { useExpense } from "../../../../contexts/ExpenseContext";
+import { useCategory } from "../../../../contexts/CategoryContext";
 
 export default function AddTransactionDialog() {
   const dialogRef = useRef(null);
@@ -12,10 +13,12 @@ export default function AddTransactionDialog() {
   const [formData, setFormData] = useState({
     title: "",
     amount: "",
-    type: "",
+    type: "expense",
     category: "",
     date: "",
   });
+
+  const { categories, setCategories } = useCategory();
 
   useEffect(
     () =>
@@ -36,7 +39,13 @@ export default function AddTransactionDialog() {
   };
 
   const resetForm = () =>
-    setFormData({ title: "", amount: "", type: "", category: "", date: "" });
+    setFormData({
+      title: "",
+      amount: "",
+      type: "expense",
+      category: "",
+      date: "",
+    });
 
   const maxDateSelection = () => {
     const maxDate = new Date();
@@ -50,6 +59,27 @@ export default function AddTransactionDialog() {
       ...prev,
       [name]: name === "amount" ? Number(value) : value, //convert amount string to number value
     }));
+  };
+
+  const getCategories = (type) => categories[type];
+
+  const renderCategories = (type) => {
+    return (
+      <>
+        <option value="" disabled>
+          {type === "income"
+            ? "Ex. Salary, Bonus, etc."
+            : "Ex. Food, Groceries, etc."}
+        </option>
+        {getCategories(type).map(({ text, value }) => {
+          return (
+            <option key={value} value={value}>
+              {text}
+            </option>
+          );
+        })}
+      </>
+    );
   };
 
   return (
@@ -111,11 +141,7 @@ export default function AddTransactionDialog() {
             onChange={handleFormChange}
             required
           >
-            <option value="" disabled>
-              Ex. Food, Groceries, etc.
-            </option>
-            <option value="food">Food</option>
-            <option value="groceries">Groceries</option>
+            {renderCategories(formData.type)}
           </select>
         </div>
         <div id="date-field-wrapper">

--- a/src/features/Transactions/components/TransactionList/TransactionList.jsx
+++ b/src/features/Transactions/components/TransactionList/TransactionList.jsx
@@ -6,6 +6,7 @@ import { useExpense } from "../../../../contexts/ExpenseContext";
 
 import { sortByDate, transformDate } from "../../../../utils/date";
 import { formatCurrency } from "../../../../utils/currency";
+import { CATEGORY_MAP } from "../../../../constants/category";
 
 export default function TransactionList() {
   const { expenses, removeExpense, setOpenDialog } = useExpense();
@@ -46,7 +47,7 @@ export default function TransactionList() {
             >
               {type}
             </span>
-            <span className="capitalize">{category}</span>
+            <span>{CATEGORY_MAP[category]}</span>
             <span
               id="delete-icon"
               className="material-icons material-symbols-outlined"


### PR DESCRIPTION
## Description

This PR introduces a dynamic category dropdown UI for both Expenses and Income in the app.

## Changes Made 

- Added default categories for both expenses and income.

- Implemented a dropdown that renders category options dynamically based on type (income or expense).

- Used a category map to convert internal category values into human-readable text.

- Added a dynamic placeholder that updates according to the selected type `(e.g., Food, Groceries for expenses, Salary, Bonus for income)`.

- Dropdown options update automatically when switching between income and expense.

## Screenshots

<img width="1438" height="670" alt="Screenshot 2025-09-11 at 3 37 12 AM" src="https://github.com/user-attachments/assets/5d70a91d-fe80-4bd5-8cba-0a4d32f4eea1" />
<img width="1438" height="659" alt="Screenshot 2025-09-11 at 3 37 41 AM" src="https://github.com/user-attachments/assets/9482e64b-fa68-4d82-84e6-e09a186f7a20" />
<img width="1440" height="671" alt="Screenshot 2025-09-11 at 3 40 01 AM" src="https://github.com/user-attachments/assets/e0e28706-a646-4921-9adb-0796bc07523d" />


## Testing Notes:

- Verified default dropdown values appear correctly for both types.

- Switching between income and expense updates the options and placeholder dynamically.

- Selecting a category correctly maps the value to the display text.