### PR TITLE
fix: prevent dialog from closing on Escape key press

### DIFF
--- a/src/features/Transactions/components/AddTransaction/AddTransaction.jsx
+++ b/src/features/Transactions/components/AddTransaction/AddTransaction.jsx
@@ -21,13 +21,19 @@ export default function AddTransactionDialog() {
 
   const { categories, setCategories } = useCategory();
 
-  useEffect(
-    () =>
-      openAddTransactionDialog
-        ? dialogRef.current.showModal()
-        : dialogRef.current.close(),
-    [openAddTransactionDialog]
-  );
+  useEffect(() => {
+    openAddTransactionDialog
+      ? dialogRef.current.showModal()
+      : dialogRef.current.close();
+
+    dialogRef.current.addEventListener("cancel", (e) => closeDialog());
+
+    return () => {
+      if (dialogRef.current) {
+        dialogRef.current.removeEventListener("cancel", (e) => closeDialog());
+      }
+    };
+  }, [openAddTransactionDialog]);
 
   const closeDialog = () => {
     setOpenAddTransactionDialog(false);


### PR DESCRIPTION

- Handled cancel event to prevent dialog from closing on `Escape` key.

- Added and cleaned up event listener inside a `useEffect` hook.