### PR TITLE
feat: store transactions in local storage

### DIFF
--- a/src/contexts/ExpenseContext.jsx
+++ b/src/contexts/ExpenseContext.jsx
@@ -1,9 +1,10 @@
 import React, { createContext, useContext, useMemo, useState } from "react";
+import { getLocalTransactions } from "../utils/localStorage";
 
 const ExpenseContext = createContext();
 
 const ExpenseProvider = ({ children }) => {
-  const [expenses, setExpense] = useState([]);
+  const [expenses, setExpense] = useState(getLocalTransactions() ?? []);
   const [openAddTransactionDialog, setOpenAddTransactionDialog] =
     useState(false);
 

--- a/src/features/Transactions/components/TransactionList/TransactionList.jsx
+++ b/src/features/Transactions/components/TransactionList/TransactionList.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 
 import "./TransactionList.css";
 import AddTransactionDialog from "../AddTransaction/AddTransaction";
@@ -7,9 +7,12 @@ import { useExpense } from "../../../../contexts/ExpenseContext";
 import { sortByDate, transformDate } from "../../../../utils/date";
 import { formatCurrency } from "../../../../utils/currency";
 import { CATEGORY_MAP } from "../../../../constants/category";
+import { storeTransactionsLocal } from "../../../../utils/localStorage";
 
 export default function TransactionList() {
   const { expenses, removeExpense, setOpenAddTransactionDialog } = useExpense();
+
+  useEffect(() => storeTransactionsLocal(expenses), [expenses]);
 
   const TransactionListHeader = () => {
     return (

--- a/src/utils/localStorage.js
+++ b/src/utils/localStorage.js
@@ -1,0 +1,7 @@
+export const storeTransactionsLocal = (transactions) => {
+    console.log(transactions)
+    localStorage.setItem("transactions", JSON.stringify(transactions));
+}
+
+export const getLocalTransactions = () =>
+    JSON.parse(localStorage.getItem("transactions"));


### PR DESCRIPTION
- Implemented logic to save all transactions into browser localStorage.
- Added retrieval of locally stored transactions for persistence across sessions.
- Transactions now remain available until explicitly cleared by the user.
