### PR TITLE
fix(config): add Vercel rewrite to fix React Router routing issue

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/"
+    }
+  ]
+}


### PR DESCRIPTION
# Fix Vercel 404 on page refresh

- Added `vercel.json` rewrite rule to serve `index.html` for all paths.

- Resolves 404 errors when refreshing or directly visiting a route on Vercel.

## Testing:

Navigate to any route (e.g.,`/transactions`).

Refresh the page → page loads correctly without 404.