### PR TITLE
feat: category editing

### DIFF
--- a/src/contexts/CategoryContext.jsx
+++ b/src/contexts/CategoryContext.jsx
@@ -41,9 +41,11 @@ const CategoryContextProvider = ({ children }) => {
       ...prev,
       income: prev.income.map((category) => {
         if (category.value === value) category.text = text;
+        return category;
       }),
       expense: prev.expense.map((category) => {
         if (category.value === value) category.text = text;
+        return category;
       }),
     }));
 

--- a/src/contexts/CategoryContext.jsx
+++ b/src/contexts/CategoryContext.jsx
@@ -36,6 +36,17 @@ const CategoryContextProvider = ({ children }) => {
       expense: prev.expense.filter(({ value }) => value !== id),
     }));
 
+  const editCategory = (value, text) =>
+    setCategories((prev) => ({
+      ...prev,
+      income: prev.income.map((category) => {
+        if (category.value === value) category.text = text;
+      }),
+      expense: prev.expense.map((category) => {
+        if (category.value === value) category.text = text;
+      }),
+    }));
+
   const CATEGORY_MAP = [...categories.expense, ...categories.income].reduce(
     (acc, obj) => ({ ...acc, [obj.value]: obj.text }),
     {}
@@ -43,7 +54,13 @@ const CategoryContextProvider = ({ children }) => {
 
   return (
     <CategoryContext.Provider
-      value={{ categories, addCategories, removeCategory, CATEGORY_MAP }}
+      value={{
+        categories,
+        addCategories,
+        removeCategory,
+        editCategory,
+        CATEGORY_MAP,
+      }}
     >
       {children}
     </CategoryContext.Provider>

--- a/src/ui-components/Categories/Categories.css
+++ b/src/ui-components/Categories/Categories.css
@@ -56,3 +56,15 @@
   border-bottom: 1px solid gray;
   outline: none;
 }
+
+.edit-input {
+  padding: 5px;
+  border-radius: 5px;
+  border: 2px solid #000000;
+  grid-column: span 2;
+}
+
+.save-icon {
+  align-self: center;
+  cursor: pointer;
+}

--- a/src/ui-components/Categories/Categories.jsx
+++ b/src/ui-components/Categories/Categories.jsx
@@ -20,7 +20,7 @@ export default function Categories() {
 
   const editBtn = (value, text) => (
     <span
-      className="link save-icon material-icons material-symbols-outlined"
+      className="link material-icons material-symbols-outlined"
       onClick={(e) => setEditInput({ edit: true, value, text })}
     >
       edit
@@ -81,7 +81,7 @@ export default function Categories() {
               onChange={handleEditChange}
             />
             <span
-              class="link material-icons material-symbols-outlined"
+              class="link save-icon material-icons material-symbols-outlined"
               onClick={doneEdit}
             >
               save

--- a/src/ui-components/Categories/Categories.jsx
+++ b/src/ui-components/Categories/Categories.jsx
@@ -1,18 +1,28 @@
-import React, { useRef, useState } from "react";
+import React, { useState } from "react";
 
 import "./Categories.css";
 import { useCategory } from "../../contexts/CategoryContext";
 import { Link } from "react-router-dom";
 
 export default function Categories() {
-  const { categories, addCategories, removeCategory } = useCategory();
+  const { categories, addCategories, removeCategory, editCategory } =
+    useCategory();
   const [formData, setFormData] = useState({
     category: "",
     type: "",
   });
 
-  const editBtn = (value) => (
-    <span className="edit-icon link material-icons material-symbols-outlined">
+  const [editInput, setEditInput] = useState({
+    edit: false,
+    text: "",
+    value: "",
+  });
+
+  const editBtn = (value, text) => (
+    <span
+      className="link save-icon material-icons material-symbols-outlined"
+      onClick={(e) => setEditInput({ edit: true, value, text })}
+    >
       edit
     </span>
   );
@@ -29,9 +39,30 @@ export default function Categories() {
   const getIncomeCategories = () => {
     return categories.income.map(({ text, value }, index) => (
       <li key={`${value}_${index}`} value={value}>
-        <span>{text}</span>
-        {editBtn(value)}
-        {deleteBtn(value)}
+        {editInput.edit && editInput.value === value ? (
+          <>
+            <input
+              className="edit-input"
+              id={`edit-input-${index}`}
+              name={value}
+              type="text"
+              value={editInput.text}
+              onChange={handleEditChange}
+            />
+            <span
+              class="link save-icon material-icons material-symbols-outlined"
+              onClick={doneEdit}
+            >
+              save
+            </span>
+          </>
+        ) : (
+          <>
+            <span>{text}</span>
+            {editBtn(value, text)}
+            {deleteBtn(value)}
+          </>
+        )}
       </li>
     ));
   };
@@ -39,9 +70,30 @@ export default function Categories() {
   const getExpenseCategories = () => {
     return categories.expense.map(({ text, value }, index) => (
       <li key={`${value}_${index}`} value={value}>
-        <span>{text}</span>
-        {editBtn(value)}
-        {deleteBtn(value)}
+        {editInput.edit && editInput.value === value ? (
+          <>
+            <input
+              className="edit-input"
+              id={`edit-input-${index}`}
+              name={value}
+              type="text"
+              value={editInput.text}
+              onChange={handleEditChange}
+            />
+            <span
+              class="link material-icons material-symbols-outlined"
+              onClick={doneEdit}
+            >
+              save
+            </span>
+          </>
+        ) : (
+          <>
+            <span>{text}</span>
+            {editBtn(value, text)}
+            {deleteBtn(value)}
+          </>
+        )}
       </li>
     ));
   };
@@ -59,6 +111,16 @@ export default function Categories() {
   };
 
   const deleteCategory = (id) => removeCategory(id);
+
+  const doneEdit = () => {
+    editCategory(editInput.value, editInput.text);
+    setEditInput({ edit: false, value: "", text: "" });
+  };
+
+  const handleEditChange = (e) => {
+    const { value } = e.target;
+    setEditInput((prev) => ({ ...prev, text: value }));
+  };
 
   return (
     <>


### PR DESCRIPTION
## Category Editing

This PR introduces the ability to edit existing categories directly within the Categories page. Users can update a category’s title.

## Features

- Editable input: Inline text input for category title

- Save button: Explicit save action to confirm edits

- Update logic: Category context updated with new values

##  Implementation

- Extended Category context to support edit operations

- Added controlled input field for category editing

- Save button triggers update logic and persists data

## ✅ Testing Steps

- Edit a category title → confirm input accepts changes

- Click Save → updated category should display immediately

- Refresh the page → updated category should still be visible (localStorage persistence)

- Verify both income and expense categories can be edited independently

## Screenshots 

<img width="1440" height="671" alt="Screenshot 2025-09-14 at 2 27 53 AM" src="https://github.com/user-attachments/assets/5febfd3a-e6a1-410b-a73c-9921e19658c5" />
